### PR TITLE
Changed printErrorMessage in the console implementation to use printB…

### DIFF
--- a/src/main/java/com/techelevator/ApplicationView.java
+++ b/src/main/java/com/techelevator/ApplicationView.java
@@ -19,7 +19,6 @@ public class ApplicationView {
     public static final int VERTICAL_CELL_PADDING = 1;
     public static final int HORIZONTAL_CELL_PADDING = 2;
 
-    private static final TextEffect ERROR_COLORS = new TextEffect(TextEffect.Code.BACKGROUND_RED, TextEffect.Code.BLACK);
     private static final TextEffect SUCCESS_COLORS = new TextEffect(TextEffect.Code.BACKGROUND_GREEN);
     private static final TextEffect NO_MATCH_COLORS = new TextEffect(TextEffect.Code.BACKGROUND_WHITE, TextEffect.Code.BLACK);
     private static final TextEffect WRONG_LOCATION_COLORS = new TextEffect(TextEffect.Code.BACKGROUND_YELLOW, TextEffect.Code.BLACK);
@@ -58,8 +57,7 @@ public class ApplicationView {
      * @param message the message to show
      */
     public void displayErrorMessage(String message) {
-        console.printErrorMessage(ERROR_COLORS.apply(message));
-        console.printBlankLine();
+        console.printErrorMessage(message);
     }
 
     /**
@@ -67,8 +65,7 @@ public class ApplicationView {
      * @param message the message to show
      */
     public void displaySuccessMessage(String message) {
-        console.printErrorMessage(SUCCESS_COLORS.apply(message));
-        console.printBlankLine();
+        console.printBanner(SUCCESS_COLORS, message);
     }
 
     /**

--- a/src/main/java/com/techelevator/utils/SystemInOutConsole.java
+++ b/src/main/java/com/techelevator/utils/SystemInOutConsole.java
@@ -14,6 +14,8 @@ import java.util.Scanner;
 
 public class SystemInOutConsole implements BasicConsole {
 
+    private static final TextEffect ERROR_COLORS = new TextEffect(TextEffect.Code.BACKGROUND_RED, TextEffect.Code.BLACK);
+
     private final Scanner input = new Scanner(System.in);
 
     @Override
@@ -39,7 +41,7 @@ public class SystemInOutConsole implements BasicConsole {
 
     @Override
     public void printErrorMessage(String message) {
-        System.out.println("***" + message + "***");
+        printBanner(ERROR_COLORS, message);
     }
 
     @Override


### PR DESCRIPTION
…anner with error colors.

### Description
- Changed the `printErrorMessage` in the console implementation to use `printBanner` with error colors.  This gives a more consistent look to the display.

### Testing
Manual testing.

### Checklist

* [x] Have you added a detailed description of what your changes do and why you'd like to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
